### PR TITLE
Correct shape in test_activations_dict_to_array input example

### DIFF
--- a/tests/lm_test.py
+++ b/tests/lm_test.py
@@ -27,8 +27,8 @@ class TestLM:
         assert result == torch.tensor(2)
 
     def test_activations_dict_to_array(self):
-        dict = {0:[[np.zeros((3,4))]],
-                1:[[np.zeros((3,4))]]}
+        dict = {0:[np.zeros((3,4))],
+                1:[np.zeros((3,4))]}
         activations = activations_dict_to_array(dict)
         assert activations.shape == (2,4,3)
 


### PR DESCRIPTION
Fix shape of test input in `test_activations_dict_to_array`.

See [this comment](https://github.com/jalammar/ecco/pull/12#issuecomment-750944397) for details.

Confirmed that all tests pass locally, with:

```bash
cd ecco
pip install -r requirements.txt
pip install -e .

python -m pytest
```