### PR TITLE
Tell pip to install from setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,1 @@
--f https://download.pytorch.org/whl/torch_stable.html
-matplotlib~=3.3.1
-numpy~=1.19.1
-ipython~=7.16.1
-scikit-learn~=0.23.2
-seaborn~=0.11.0
-transformers~=3.1.0
-pytest~=6.1.2
-setuptools~=49.6.0
-torch~=1.6.0
-torchvision~=0.7.0
-
+-e .


### PR DESCRIPTION
Forces `pip install -r requirements.txt` to install the same package versions specified in `setup.py`.

For details, see [this comment](https://github.com/jalammar/ecco/pull/12#issuecomment-750944397).

Confirmed that tests pass locally after merging this and #13 .  (Since #13 fixes tests, they won't pass until it is merged.)