### PR TITLE
Adds a model config field use_causal_lm and config entries for gpt-neo

### DIFF
--- a/src/ecco/__init__.py
+++ b/src/ecco/__init__.py
@@ -16,6 +16,7 @@ __version__ = '0.0.14'
 from ecco.lm import LM
 from transformers import AutoTokenizer, AutoModelForCausalLM, AutoModel
 from typing import Optional, List
+from ecco.util import load_config
 
 
 def from_pretrained(hf_model_id: str,
@@ -48,8 +49,13 @@ Args:
 """
     # TODO: Should specify task/head in a cleaner way. Allow masked LM. T5 generation.
     # Likely use model-config. Have a default. Allow user to specify head?
-    if 'gpt2' not in hf_model_id:
-        tokenizer = AutoTokenizer.from_pretrained(hf_model_id)
+
+    model_config = load_config(hf_model_id)
+    use_causal_lm = model_config.get('use_causal_lm',False)
+
+    tokenizer = AutoTokenizer.from_pretrained(hf_model_id)
+    
+    if not use_causal_lm:
         model = AutoModel.from_pretrained(hf_model_id,
                                                      output_hidden_states=hidden_states,
                                                      output_attentions=attention)

--- a/src/ecco/lm.py
+++ b/src/ecco/lm.py
@@ -15,7 +15,7 @@ from operator import attrgetter
 import re
 
 from transformers import GPT2Model
-import yaml
+from ecco.util import load_config
 
 
 class LM(object):
@@ -78,10 +78,8 @@ class LM(object):
 
         # For each model, this indicates the layer whose activations
         # we will collect
-        configs = yaml.safe_load(open(os.path.join(self._path, "model-config.yaml")))
-
+        self.model_config = load_config(self.model_name)
         try:
-            self.model_config = configs[self.model_name]
             self.model_embeddings = self.model_config['embedding']
             embeddings_layer_name = self.model_config['embedding']
             embed_retriever = attrgetter(embeddings_layer_name)
@@ -89,9 +87,7 @@ class LM(object):
             self.collect_activations_layer_name_sig = self.model_config['activations'][0]
         except KeyError:
             raise ValueError(
-                   f"The model '{self.model_name}' is not defined in Ecco's 'model-config.yaml' file and"
-                   f" so is not explicitly supported yet. Supported models are:",
-                   list(configs.keys())) from KeyError()
+                   f"The model '{self.model_name}' is not correctly configured in Ecco's 'model-config.yaml' file") from KeyError()
 
         self._hooks = {}
         self._reset()
@@ -571,3 +567,5 @@ def activations_dict_to_array(activations_dict):
     activations = np.swapaxes(activations, 0, 1)
     # print('after swapping: ', activations.shape)
     return activations
+
+

--- a/src/ecco/model-config.yaml
+++ b/src/ecco/model-config.yaml
@@ -1,17 +1,21 @@
 # GPT2
 gpt2:
+    use_causal_lm: true
     embedding: "transformer.wte.weight" # String. Directly accessed
     activations: # Regex pattern
     - 'mlp\.c_proj'
 gpt2-medium:
+    use_causal_lm: true
     embedding: "transformer.wte.weight"
     activations:
     - 'mlp\.c_proj'
 gpt2-xl:
+    use_causal_lm: true
     embedding: "transformer.wte.weight"
     activations:
     - 'mlp\.c_proj'
 distilgpt2:
+    use_causal_lm: true
     embedding: "transformer.wte.weight"
     activations:
     - 'mlp\.c_proj'
@@ -100,6 +104,7 @@ facebook/bart-large-mnli:
     - 'fc2'
 # DUMMY MODELS
 'sshleifer/tiny-gpt2':
+  use_causal_lm: true
   embedding: "transformer.wte.weight"
   activations:
     - 'mlp.c_proj'
@@ -107,4 +112,19 @@ facebook/bart-large-mnli:
   embedding: "embeddings.word_embeddings"
   activations:
     - '\d+\.output\.dense'
-
+#EleutherAI
+EleutherAI/gpt-neo-125M:
+    use_causal_lm: true
+    embedding: "transformer.wte.weight"
+    activations:
+    - 'mlp\.c_proj'
+EleutherAI/gpt-neo-1.3B:
+    use_causal_lm: true
+    embedding: "transformer.wte.weight"
+    activations:
+    - 'mlp\.c_proj'
+EleutherAI/gpt-neo-2.7B:
+    use_causal_lm: true
+    embedding: "transformer.wte.weight"
+    activations:
+    - 'mlp\.c_proj'

--- a/src/ecco/util.py
+++ b/src/ecco/util.py
@@ -1,3 +1,6 @@
+import yaml
+import os
+
 # CHeck if running from inside jupyter
 # From https://stackoverflow.com/questions/47211324/check-if-module-is-running-in-jupyter-or-not
 def type_of_script():
@@ -9,3 +12,15 @@ def type_of_script():
             return 'ipython'
     except:
         return 'terminal'
+
+def load_config(model_name):
+    path = os.path.dirname(__file__) 
+    configs = yaml.safe_load(open(os.path.join(path, "model-config.yaml")))
+    try:
+        model_config = configs[model_name]
+    except KeyError:
+        raise ValueError(
+                f"The model '{model_name}' is not defined in Ecco's 'model-config.yaml' file and"
+                f" so is not explicitly supported yet. Supported models are:",
+                list(configs.keys())) from KeyError()
+    return model_config


### PR DESCRIPTION
Adding gpt-neo models to model-config.yaml failed because the model needs to be loaded using AutoModelForCausalLM, but __init__ identified such models by looking for gpt2 in the name. A TODO comment in __init__ mentioned using config instead. I refactored config loading slightly to enable this - not sure if that is the direction you intended or not.


