### PR TITLE
Added installation section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,22 @@ Ecco runs inside Jupyter notebooks. It is built on top of [pytorch](https://pyto
 
 Ecco is not concerned with training or fine-tuning models. Only exploring and understanding existing pre-trained models.
 
+## Installation
+
+You can install `ecco` either with `pip` or with `conda`.
+
+**with pip**
+
+```sh
+pip install ecco
+```
+
+**with conda**
+
+```sh
+conda install -c conda-forge ecco
+```
+
 ## Tutorials
 - Video: [Take A Look Inside Language Models With Ecco](https://www.youtube.com/watch?v=rHrItfNeuh0). \[<a href="https://colab.research.google.com/github/jalammar/ecco/blob/main/notebooks/Language_Models_and_Ecco_PyData_Khobar.ipynb">Colab Notebook</a>]
 

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,20 @@
 <br />
 <br />
 
-[![PyPI Package latest release](https://img.shields.io/pypi/v/ecco.svg)](https://pypi.org/project/ecco)
-[![Supported versions](https://img.shields.io/pypi/pyversions/ecco.svg)](https://pypi.org/project/ecco)
+<!--- BADGES: START --->
+[![GitHub - License](https://img.shields.io/github/license/jalammar/ecco?logo=github&style=flat&color=green)][#github-license]
+[![PyPI - Latest Package Version](https://img.shields.io/pypi/v/ecco?logo=pypi&style=flat&color=orange)][#pypi-package]
+[![PyPI - Supported Python Versions](https://img.shields.io/pypi/pyversions/ecco?logo=pypi&style=flat&color=blue)][#pypi-package]
+[![Conda - Platform](https://img.shields.io/conda/pn/conda-forge/ecco?logo=anaconda&style=flat)][#conda-forge-package]
+[![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/ecco?logo=anaconda&style=flat&color=orange)][#conda-forge-package]
+[![Docs - GitHub.io](https://img.shields.io/static/v1?logo=readthedocs&style=flat&color=pink&label=docs&message=ecco)][#docs-package]
+
+
+[#github-license]: https://github.com/jalammar/ecco/blob/main/LICENSE
+[#pypi-package]: https://pypi.org/project/ecco/
+[#conda-forge-package]: https://anaconda.org/conda-forge/ecco
+[#docs-package]: https://ecco.readthedocs.io/
+<!--- BADGES: END --->
 
 
 Ecco is a python library for exploring and explaining Natural Language Processing models using interactive visualizations. 

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,22 @@ Documentation: [ecco.readthedocs.io](https://ecco.readthedocs.io/)
     - Evolution of processing a token through the layers of the model ([Logit lens](https://www.lesswrong.com/posts/AcKRB8wDpdaN6v6ru/interpreting-gpt-the-logit-lens))
     - Candidate output tokens and their probabilities (at each layer in the model)
 
+## Installation
+
+You can install `ecco` either with `pip` or with `conda`.
+
+**with pip**
+
+```sh
+pip install ecco
+```
+
+**with conda**
+
+```sh
+conda install -c conda-forge ecco
+```
+
 ## Examples:
 
 ### What is the sentiment of this film review?


### PR DESCRIPTION
This adds installation instruction for `pip` and `conda` to the *readme* and the *docs*. This PR is representative of the work done (https://github.com/conda-forge/staged-recipes/pull/17388) to make ecco available on conda-forge.

I also added some relevant badges.

<!--- BADGES: START --->
[![GitHub - License](https://img.shields.io/github/license/jalammar/ecco?logo=github&style=flat&color=green)][#github-license]
[![PyPI - Latest Package Version](https://img.shields.io/pypi/v/ecco?logo=pypi&style=flat&color=orange)][#pypi-package]
[![PyPI - Supported Python Versions](https://img.shields.io/pypi/pyversions/ecco?logo=pypi&style=flat&color=blue)][#pypi-package]
[![Conda - Platform](https://img.shields.io/conda/pn/conda-forge/ecco?logo=anaconda&style=flat)][#conda-forge-package]
[![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/ecco?logo=anaconda&style=flat&color=orange)][#conda-forge-package]
[![Docs - GitHub.io](https://img.shields.io/static/v1?logo=readthedocs&style=flat&color=pink&label=docs&message=ecco)][#docs-package]


[#github-license]: https://github.com/jalammar/ecco/blob/main/LICENSE
[#pypi-package]: https://pypi.org/project/ecco/
[#conda-forge-package]: https://anaconda.org/conda-forge/ecco
[#docs-package]: https://ecco.readthedocs.io/
<!--- BADGES: END --->

Closes #54.

cc: @jalammar 