### PR TITLE
[bug fix] seems the hot fix for T5 generation is not need for later version of transformers

### DIFF
--- a/src/ecco/lm.py
+++ b/src/ecco/lm.py
@@ -199,7 +199,7 @@ class LM(object):
         # Get decoder input ids
         if self.model_type == 'enc-dec': # FIXME: only done because causal LMs like GPT-2 have the _prepare_decoder_input_ids_for_generation method but do not use it
             assert len(input_ids.size()) == 2 # will break otherwise
-            if transformers.__version__ >= '4.13': # ALSO FIXME: awful hack. But seems to work?
+            if transformers.__version__ >= '4.13' and transformers.__version__ < '4.6.1': # ALSO FIXME: awful hack. But seems to work?
                 decoder_input_ids = self.model._prepare_decoder_input_ids_for_generation(input_ids.shape[0], None, None)
             else:
                 decoder_input_ids = self.model._prepare_decoder_input_ids_for_generation(input_ids, None, None)
@@ -636,7 +636,7 @@ class LM(object):
                     parentDiv: '{viz_id}',
                     data: {json.dumps(data)},
                     tokenization_config: {json.dumps(self.model_config['tokenizer_config'])}
-            
+
             }})
          }}, function (err) {{
             console.log(err);


### PR DESCRIPTION
Hi Jay,

Thanks for the great tool that you built.
I was playing around with it and ran into the following error on the T5-small example from readme.
```sh
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/tmp/ipykernel_1710801/2602227185.py in <module>
      4 to feed my soul. I didn't expect it to entirely blow my mind."""
      5 
----> 6 output = lm.generate(f"sst2 sentence: {review}", generate=1, do_sample=False, attribution=['ig'])
      7 output.primary_attributions(attr_method='ig', ignore_tokens=[0,1,2,3,4,5,6,43,44])

~/ecco/src/ecco/lm.py in generate(self, input_str, max_length, temperature, top_k, top_p, do_sample, attribution, generate, beam_size, **generate_kwargs)
    201             assert len(input_ids.size()) == 2 # will break otherwise
    202             if transformers.__version__ >= '4.13': # ALSO FIXME: awful hack. But seems to work?
--> 203                 decoder_input_ids = self.model._prepare_decoder_input_ids_for_generation(input_ids.shape[0], None, None)
    204             else:
    205                 decoder_input_ids = self.model._prepare_decoder_input_ids_for_generation(input_ids, None, None)

~/miniconda3/envs/ecco/lib/python3.9/site-packages/transformers/generation_utils.py in _prepare_decoder_input_ids_for_generation(self, input_ids, decoder_start_token_id, bos_token_id)
    420         decoder_start_token_id = self._get_decoder_start_token_id(decoder_start_token_id, bos_token_id)
    421         decoder_input_ids = (
--> 422             torch.ones((input_ids.shape[0], 1), dtype=torch.long, device=input_ids.device) * decoder_start_token_id
    423         )
    424         return decoder_input_ids

AttributeError: 'int' object has no attribute 'shape'
```
Here is the example code I was playing with
```python
import ecco
lm = ecco.from_pretrained('t5-small', verbose=False)
review="""I have a well-documented weakness for sci-fi and expected Dune 
to feed my soul. I didn't expect it to entirely blow my mind."""

output = lm.generate(f"sst2 sentence: {review}", generate=1, do_sample=False, attribution=['ig'])
output.primary_attributions(attr_method='ig', ignore_tokens=[0,1,2,3,4,5,6,43,44])
```

After some debugging, I realized that the hotfix for T5 generation from previous commits might not be need. But I am not sure starting which exact version of transformers don't need this hack, so I thought it might be a good idea to file a quick PR for this to bring up attention.