### PR TITLE
[bugfix] fix comparison of transformers version in lm generate

### DIFF
--- a/src/ecco/lm.py
+++ b/src/ecco/lm.py
@@ -17,6 +17,7 @@ from typing import Optional, Any, List, Tuple, Dict, Union
 from operator import attrgetter
 import re
 from ecco.util import is_partial_token, strip_tokenizer_prefix
+from packaging import version
 
 
 class LM(object):
@@ -199,7 +200,7 @@ class LM(object):
         # Get decoder input ids
         if self.model_type == 'enc-dec': # FIXME: only done because causal LMs like GPT-2 have the _prepare_decoder_input_ids_for_generation method but do not use it
             assert len(input_ids.size()) == 2 # will break otherwise
-            if transformers.__version__ >= '4.13': # ALSO FIXME: awful hack. But seems to work?
+            if version.parse(transformers.__version__) >= version.parse('4.13'): # ALSO FIXME: awful hack. But seems to work?
                 decoder_input_ids = self.model._prepare_decoder_input_ids_for_generation(input_ids.shape[0], None, None)
             else:
                 decoder_input_ids = self.model._prepare_decoder_input_ids_for_generation(input_ids, None, None)


### PR DESCRIPTION
**Problem:**
The comparison of versions in the lm generate method is buggy as it is just comparing strings. For e.g. "4.6.1" > "4.13" when just comparing strings, but that is not the intended behavior when comparing versions.

**Solution:**
Use the `version.parse` functionality of the `packaging` package (that is already installed as a requirement of one of the required packages present in the requirements.txt). This will make the string version to be binded to a Version object that has the comparison methods implemented with the intended behavior for version comparison.

**Local setup to reproduce bug:**
Code:
```
import ecco

lm = ecco.from_pretrained(
    'tscholak/1zha5ono',
    model_config={'embedding': 'shared.weight',
    'type': 'enc-dec',
    'activations': ['wo'],
    'token_prefix': '▁',
    'partial_token_prefix': ''}
)
output = lm.generate("some test string", max_length=500, do_sample=False, attribution=['grad_x_input'])
```
Error:
![image](https://user-images.githubusercontent.com/38245862/148696975-5c1e9350-cf8b-4c28-8fb1-654b01f431ea.png)
Relevant Packages version:
```
ecco: 0.1.1
transformers: 4.6.1
```