### PR TITLE
Add support for PEGASUS model

### DIFF
--- a/src/ecco/model-config.yaml
+++ b/src/ecco/model-config.yaml
@@ -212,14 +212,98 @@ facebook/bart-large-mnli:
     partial_token_prefix: '##'
 
 # PEGASUS
+google/pegasus-large:
+    embedding: 'model.shared.weight'
+    type: 'enc-dec'
+    activations:
+        - 'fc1'
+    token_prefix: '▁'
+    partial_token_prefix: ''
+google/pegasus-xsum:
+    embedding: 'model.shared.weight'
+    type: 'enc-dec'
+    activations:
+        - 'fc1'
+    token_prefix: '▁'
+    partial_token_prefix: ''
+google/pegasus-gigaword:
+    embedding: 'model.shared.weight'
+    type: 'enc-dec'
+    activations:
+        - 'fc1'
+    token_prefix: '▁'
+    partial_token_prefix: ''
 google/pegasus-cnn_dailymail:
     embedding: 'model.shared.weight'
     type: 'enc-dec'
     activations:
         - 'fc1'
-    token_prefix: '_'
+    token_prefix: '▁'
     partial_token_prefix: ''
-    
+google/pegasus-wikihow:
+    embedding: 'model.shared.weight'
+    type: 'enc-dec'
+    activations:
+        - 'fc1'
+    token_prefix: '▁'
+    partial_token_prefix: ''
+google/pegasus-reddit_tifu:
+    embedding: 'model.shared.weight'
+    type: 'enc-dec'
+    activations:
+        - 'fc1'
+    token_prefix: '▁'
+    partial_token_prefix: ''
+google/pegasus-pubmed:
+    embedding: 'model.shared.weight'
+    type: 'enc-dec'
+    activations:
+        - 'fc1'
+    token_prefix: '▁'
+    partial_token_prefix: ''
+google/pegasus-newsroom:
+    embedding: 'model.shared.weight'
+    type: 'enc-dec'
+    activations:
+        - 'fc1'
+    token_prefix: '▁'
+    partial_token_prefix: ''
+google/pegasus-multi_news:
+    embedding: 'model.shared.weight'
+    type: 'enc-dec'
+    activations:
+        - 'fc1'
+    token_prefix: '▁'
+    partial_token_prefix: ''
+google/pegasus-billsum:
+    embedding: 'model.shared.weight'
+    type: 'enc-dec'
+    activations:
+        - 'fc1'
+    token_prefix: '▁'
+    partial_token_prefix: ''
+google/pegasus-big_patent:
+    embedding: 'model.shared.weight'
+    type: 'enc-dec'
+    activations:
+        - 'fc1'
+    token_prefix: '▁'
+    partial_token_prefix: ''  
+google/pegasus-arxiv:
+    embedding: 'model.shared.weight'
+    type: 'enc-dec'
+    activations:
+        - 'fc1'
+    token_prefix: '▁'
+    partial_token_prefix: ''
+google/pegasus-aeslc:
+    embedding: 'model.shared.weight'
+    type: 'enc-dec'
+    activations:
+        - 'fc1'
+    token_prefix: '▁'
+    partial_token_prefix: ''  
+
 # DUMMY MODELS
 'sshleifer/tiny-gpt2':
     embedding: "transformer.wte.weight"

--- a/src/ecco/model-config.yaml
+++ b/src/ecco/model-config.yaml
@@ -211,6 +211,15 @@ facebook/bart-large-mnli:
     token_prefix: ''
     partial_token_prefix: '##'
 
+# PEGASUS
+google/pegasus-cnn_dailymail:
+    embedding: 'model.shared.weight'
+    type: 'enc-dec'
+    activations:
+        - 'fc1'
+    token_prefix: '_'
+    partial_token_prefix: ''
+    
 # DUMMY MODELS
 'sshleifer/tiny-gpt2':
     embedding: "transformer.wte.weight"


### PR DESCRIPTION
I would like to add the support of PEGASUS in model-config.yaml.

PEGASUS model is an encoder-decoder type and the implementation is completely inherited from BartForConditionalGeneration. So the config is similar to the BART model.

Notes: This is my first time making a pull request on an open-source project, but hope this helps!