### PR TITLE
feat(LM): attributions for SequenceClassification

### DIFF
--- a/src/ecco/attribution.py
+++ b/src/ecco/attribution.py
@@ -64,7 +64,8 @@ def compute_primary_attributions_scores(attr_method : str, model: transformers.P
             output = model(inputs_embeds=input_, decoder_inputs_embeds=decoder_, **extra_forward_args)
         else:
             output = model(inputs_embeds=input_, **extra_forward_args)
-        return F.softmax(output.logits[:, -1, :], dim=-1)
+        # SequenceClassfication models only output 1 set of logits per batch, resulting in 2 dimensional outputs
+        return F.softmax(output.logits[:, -1, :] if len(output.logits.shape) == 3 else output.logits, dim=-1)
 
     def normalize_attributes(attributes: torch.Tensor) -> torch.Tensor:
         # attributes has shape (batch, sequence size, embedding dim)


### PR DESCRIPTION
#64 @jalammar 
Single-class sequence classification with BERT and RoBERTa now allows primary attributions. `tox` command run.
### Changes

- `LM` class: new `classify` method. Mimics `generate` in tokenization, forward pass, and hidden states collection.
- attributions.py: `model_forward`'s softmax step also allows 2D model outputs
https://github.com/jamesjin0516/ecco/blob/558cb1e9d35c2551e1b4ad3add497124b0a48919/src/ecco/attribution.py#L68
### TODOs

- `OutputSeq` class: `all_token_ids` produced by `classify` currently contains **index of predicted label**, incorrectly **decoded** as a **token**.
- Potentially include support for multi-class classification